### PR TITLE
Add gocl_queue_flush() and gocl_queue_finish() for cleanups

### DIFF
--- a/gocl/gocl-queue.h
+++ b/gocl/gocl-queue.h
@@ -54,6 +54,10 @@ GType                  gocl_queue_get_type                   (void) G_GNUC_CONST
 
 guint                  gocl_queue_get_flags                  (GoclQueue *self);
 
+gboolean               gocl_queue_flush                      (GoclQueue *self);
+
+gboolean               gocl_queue_finish                     (GoclQueue *self);
+
 G_END_DECLS
 
 #endif /* __GOCL_QUEUE_H__ */


### PR DESCRIPTION
I would assume that flushing the queue is a sane behavior when it's being disposed, otherwise some issued commands can be simply lost.