### PR TITLE
Add gocl_program_get_build_status() and gocl_program_get_build_info()

### DIFF
--- a/gocl/gocl-decls.h
+++ b/gocl/gocl-decls.h
@@ -113,6 +113,26 @@ typedef enum
   GOCL_IMAGE_TYPE_3D        = CL_MEM_OBJECT_IMAGE3D
 } GoclImageType;
 
+/**
+ * GoclProgramBuildStatus:
+ */
+typedef enum
+{
+  GOCL_PROGRAM_BUILD_NONE        = CL_BUILD_NONE,
+  GOCL_PROGRAM_BUILD_ERROR       = CL_BUILD_ERROR,
+  GOCL_PROGRAM_BUILD_SUCCESS     = CL_BUILD_SUCCESS,
+  GOCL_PROGRAM_BUILD_IN_PROGRESS = CL_BUILD_IN_PROGRESS
+} GoclProgramBuildStatus;
+
+/**
+ * GoclProgramBuildInfo:
+ */
+typedef enum
+{
+  GOCL_PROGRAM_BUILD_OPTIONS = CL_PROGRAM_BUILD_OPTIONS,
+  GOCL_PROGRAM_BUILD_LOG     = CL_PROGRAM_BUILD_LOG
+} GoclProgramBuildInfo;
+
 G_END_DECLS
 
 #endif /* __GOCL_DECLS_H__ */

--- a/gocl/gocl-program.h
+++ b/gocl/gocl-program.h
@@ -77,6 +77,11 @@ void                   gocl_program_build                      (GoclProgram     
 gboolean               gocl_program_build_finish               (GoclProgram   *self,
                                                                 GAsyncResult  *result,
                                                                 GError       **error);
+GoclProgramBuildStatus gocl_program_get_build_status           (GoclProgram *self,
+                                                                GoclDevice *device);
+gchar *                gocl_program_get_build_info             (GoclProgram          *self,
+                                                                GoclDevice           *device,
+                                                                GoclProgramBuildInfo  build_info);
 
 G_END_DECLS
 


### PR DESCRIPTION
I already tested these two with an offline branch of Vast.

It's a bit weird to return `-1` for the build status to indicate an external error and I really would prefer using `GError`, but that would be inconsistent with the rest of the API. Maybe for the `1.0` we should consider a full move to `GError`?